### PR TITLE
fix: añadir dependencia anthropic para mocks de tests en CI

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,4 +8,4 @@ whitenoise>=6.6,<7.0
 requests>=2.31,<3.0
 dj-database-url>=2.1,<3.0
 psycopg2-binary>=2.9,<3.0
-
+anthropic>=0.18,<0.19


### PR DESCRIPTION
## Resumen

- Añade `anthropic` a `backend/requirements.txt` para que los mocks de los tests de CI puedan importar el módulo correctamente
- Commit suelto que quedó fuera de los PR #11 y #12 ya mergeados de esta rama

## Plan de pruebas

- [ ] Verificar que el pipeline de CI pasa sin `ModuleNotFoundError: No module named 'anthropic'`